### PR TITLE
refactored Kfloss

### DIFF
--- a/experiments/UCAS_AOD.sh
+++ b/experiments/UCAS_AOD.sh
@@ -1,3 +1,3 @@
 #python train.py --data_folder data/UCAS_AOD --model_name tmp --number_of_classes 2 --batch_size 4 --img_size 416 --dataset UCAS_AOD --no_multiscale
 
-python train.py --model_name ttt  --config data/hyp.yaml --data data/UCAS_AOD.yaml
+python train.py --model_name basekf  --config data/hyp.yaml --data data/UCAS_AOD.yaml

--- a/lib/kfloss.py
+++ b/lib/kfloss.py
@@ -1,0 +1,176 @@
+# Copyright (c) SJTU. All rights reserved.
+import torch
+from torch import nn
+
+
+
+def xy_wh_r_2_xy_sigma(xywhr):
+    """Convert oriented bounding box to 2-D Gaussian distribution.
+
+    Args:
+        xywhr (torch.Tensor): rbboxes with shape (N, 5).
+
+    Returns:
+        xy (torch.Tensor): center point of 2-D Gaussian distribution
+            with shape (N, 2).
+        sigma (torch.Tensor): covariance matrix of 2-D Gaussian distribution
+            with shape (N, 2, 2).
+    """
+
+    _shape = xywhr.size()
+    assert _shape[-1] == 5
+    xy = xywhr[..., :2]
+    wh = xywhr[..., 2:4].clamp(min=1e-7, max=1e7).reshape(-1, 2)
+    r = xywhr[..., 4]
+    cos_r = torch.cos(r)
+    sin_r = torch.sin(r)
+    R = torch.stack((cos_r, -sin_r, sin_r, cos_r), dim=-1).reshape(-1, 2, 2)
+    S = 0.5 * torch.diag_embed(wh)
+
+    sigma = R.bmm(S.square()).bmm(R.permute(0, 2,
+                                            1)).reshape(_shape[:-1] + (2, 2))
+
+    return xy, sigma
+
+
+
+def kfiou_loss(pred,
+               target,
+               pred_decode=None,
+               targets_decode=None,
+               fun="exp",
+               beta=1.0,
+               eps=1e-6):
+    """Kalman filter IoU loss.
+
+    Args:
+        pred (torch.Tensor): Predicted bboxes.
+        target (torch.Tensor): Corresponding gt bboxes.
+        pred_decode (torch.Tensor): Predicted decode bboxes.
+        targets_decode (torch.Tensor): Corresponding gt decode bboxes.
+        fun (str): The function applied to distance. Defaults to None.
+        beta (float): Defaults to 1.0/9.0.
+        eps (float): Defaults to 1e-6.
+
+    Returns:
+        loss (torch.Tensor)
+    """
+    xy_p = pred[:, :2]
+    xy_t = target[:, :2]
+    _, Sigma_p = xy_wh_r_2_xy_sigma(pred_decode)
+    _, Sigma_t = xy_wh_r_2_xy_sigma(targets_decode)
+
+    # Smooth-L1 norm
+    diff = torch.abs(xy_p - xy_t)
+    xy_loss = torch.where(diff < beta, 0.5 * diff * diff / beta,
+                          diff - 0.5 * beta).sum(dim=-1)
+    
+    Vb_p = 4 * Sigma_p.det().sqrt()
+    Vb_t = 4 * Sigma_t.det().sqrt()
+
+    K = Sigma_p.bmm((Sigma_p + Sigma_t).inverse())
+    Sigma = Sigma_p - K.bmm(Sigma_p)
+    Vb = 4 * Sigma.det().sqrt()
+
+    Vb = torch.where(torch.isnan(Vb), torch.full_like(Vb, 0), Vb)
+    # print(Vb)
+    # print(Vb_t)
+    # print(Vb_p)
+    KFIoU = Vb / (Vb_p + Vb_t - Vb + eps)
+    KFIoU = torch.where(torch.isnan(KFIoU), torch.full_like(KFIoU, 0), KFIoU)
+
+    if fun == 'ln':
+        kf_loss = -torch.log(KFIoU + eps)
+    elif fun == 'exp':
+        kf_loss = torch.exp(1 - KFIoU) - 1
+    else:
+        kf_loss = 1 - KFIoU
+    # print(xy_loss)
+
+    #print(kf_loss.mean())
+
+    loss = (xy_loss + kf_loss).clamp(0)
+    #print(loss)
+
+    return loss.mean(), xy_loss.mean(), kf_loss.mean()
+
+
+class KFLoss(nn.Module):
+    """Kalman filter based loss.
+
+    Args:
+        fun (str, optional): The function applied to distance.
+            Defaults to 'log1p'.
+        reduction (str, optional): The reduction method of the
+            loss. Defaults to 'mean'.
+        loss_weight (float, optional): The weight of loss. Defaults to 1.0.
+
+    Returns:
+        loss (torch.Tensor)
+    """
+
+    def __init__(self,
+                 fun='none',
+                 reduction='mean',
+                 ):
+        super(KFLoss, self).__init__()
+        assert reduction in ['none', 'sum', 'mean']
+        assert fun in ['none', 'ln', 'exp']
+        self.fun = fun
+        self.reduction = reduction
+
+    def forward(self,
+                pred,
+                target,
+                weight=None,
+                avg_factor=None,
+                pred_decode=None,
+                targets_decode=None,
+                reduction_override=None,
+                ):
+        """Forward function.
+
+        Args:
+            pred (torch.Tensor): Predicted convexes.
+            target (torch.Tensor): Corresponding gt convexes.
+            weight (torch.Tensor, optional): The weight of loss for each
+                prediction. Defaults to None.
+            avg_factor (int, optional): Average factor that is used to average
+                the loss. Defaults to None.
+            pred_decode (torch.Tensor): Predicted decode bboxes.
+            targets_decode (torch.Tensor): Corresponding gt decode bboxes.
+            reduction_override (str, optional): The reduction method used to
+               override the original reduction method of the loss.
+               Defaults to None.
+
+        Returns:
+            loss (torch.Tensor)
+        """
+        assert reduction_override in (None, 'none', 'mean', 'sum')
+        reduction = (
+            reduction_override if reduction_override else self.reduction)
+        if (weight is not None) and (not torch.any(weight > 0)) and (
+                reduction != 'none'):
+            return (pred * weight).sum()
+        if weight is not None and weight.dim() > 1:
+            assert weight.shape == pred.shape
+            weight = weight.mean(-1)
+
+        return kfiou_loss(
+            pred,
+            target,
+            fun=self.fun,
+            pred_decode=pred_decode,
+            targets_decode=targets_decode)
+
+
+        # return kfiou_loss(
+        #     pred,
+        #     target,
+        #     fun=self.fun,
+        #     weight=weight,
+        #     avg_factor=avg_factor,
+        #     pred_decode=pred_decode,
+        #     targets_decode=targets_decode,
+        #     reduction=reduction,
+        #     **kwargs) * self.loss_weight

--- a/train.py
+++ b/train.py
@@ -159,7 +159,7 @@ class Train:
             self.model.train()
             total_train_loss = {}
       
-            logger.info(('\n' + '%10s' * 6) % ('Epoch', 'lr', 'box_loss', 'obj_loss', 'cls_loss', 'total'))
+            logger.info(('\n' + '%10s' * 7) % ('Epoch', 'lr', 'kf_loss','xy_loss', 'obj_loss', 'cls_loss', 'total'))            
             pbar = enumerate(train_dataloader)
             pbar = tqdm.tqdm(pbar, total=len(train_dataloader))
             for batch, (_, imgs, targets) in pbar:
@@ -183,8 +183,8 @@ class Train:
                     optimizer.zero_grad()
                 
                 # print info
-                s = ('%10s'  + '%10.4g' * 5) % (
-                    '%g/%g' % (epoch + 1, self.args.epochs), optimizer.param_groups[0]["lr"], loss_items["reg_loss"],
+                s = ('%10s'  + '%10.4g' * 6) % (
+                    '%g/%g' % (epoch + 1, self.args.epochs), optimizer.param_groups[0]["lr"], loss_items["kf_loss"],loss_items["xy_loss"],
                     loss_items["conf_loss"], loss_items["cls_loss"], loss_items["total_loss"])
                 # store loss items
                 for item in loss_items:
@@ -230,7 +230,7 @@ if __name__ == "__main__":
     parser.add_argument("--lr", type=float, default=0.001, help="learning rate")
     parser.add_argument("--batch_size", type=int, default=4, help="size of batches")
     parser.add_argument("--img_size", type=int, default=608, help="size of each image dimension")
-    parser.add_argument("--weights_path", type=str, default="weights/yolov4.pth", help="path to pretrained weights file")
+    parser.add_argument("--weights_path", type=str, default="weights/pretrained/yolov4.pth", help="path to pretrained weights file")
     parser.add_argument("--model_name", type=str, default="trash", help="new model name")
     parser.add_argument("--data", type=str, default="", help=".yaml path for data")
     parser.add_argument("--config", type=str, default="", help=".yaml path for configs")


### PR DESCRIPTION
**Don't merge just review the kfloss code!!!!!**
The kfloss is composed of 2 losses: xy_loss(center point diff) and kf_loss(distribution diff). I divided two losses separately for printing purposes, but overall losses are calculated together, so there's no need to modify if u want to take a look and train. 
From the original source code, it requires inputting xy loss for not decoded prediction and target, while the decoded version for kf loss, I'm still not quite sure why is that the case, please help me justify if u can come up with some notions.